### PR TITLE
Update extension id from `v.V` to `vlanguage.vscode-vlang`

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
 	},
 
 	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": ["v.V"],
+	"extensions": ["vlanguage.vscode-vlang"],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],


### PR DESCRIPTION
Corrects the extension id to automatically install on creating the container