### PR TITLE
fix: normalize v.mod metadata

### DIFF
--- a/v.mod
+++ b/v.mod
@@ -2,6 +2,7 @@ Module {
         name: 'hello-vsl'
         version: '0.1.2'
         license: 'MIT'
-	      repo_url: 'https://github.com/ulises-jeremias/hello-vsl'
+        repo_url: 'https://github.com/ulises-jeremias/hello-vsl'
+        description: 'Starter template for the V Scientific Library (VSL)'
         dependencies: ['vsl']
 }


### PR DESCRIPTION
## What

Fixes #7 by normalizing the `repo_url` indentation and adding the missing module description.

## Why

The metadata should be consistently formatted and include a description for V tooling and package consumers.

## Testing

- `git diff --check`
- Static check confirmed `v.mod` has no tab characters and contains the requested description
- V compiler was unavailable in the local environment