### PR TITLE
docs: add Discord community badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VSL &ndash; V scientific library (Hello World)
 
+[![Discord](https://img.shields.io/discord/1527933660764831825?label=Discord&logo=discord&logoColor=white)](https://discord.gg/dwFTsR7fK2)
+
 This simple example is a start point for developing applications with VSL.
 
 To run this code:


### PR DESCRIPTION
## Summary
- Add Discord community badge linking to https://discord.gg/dwFTsR7fK2
- Place it with existing README badges (or under the title when none exist), matching each README's badge style

## Test plan
- [ ] Confirm badge renders on GitHub README preview
- [ ] Confirm click opens Discord invite
- [ ] Confirm member count shield loads (server ID 1527933660764831825)
